### PR TITLE
let git ignore any generated shared objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ lib/*
 doc/tags
 *.obj
 *.o
+*.so
 *.swp
 *~


### PR DESCRIPTION
Which makes using this as git submodule less painful because you can stay in
sync with upstream/master.
